### PR TITLE
Hosting: Raspberry Pi + Cloudflare Tunnel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Raspberry Pi
+
+# Builds the monorepo on a self-hosted runner that lives ON the Pi (outbound-only,
+# so it works behind the home double-NAT — no inbound ports needed) and publishes
+# each app's static build to the nginx webroots that Cloudflare Tunnel serves.
+#
+# Prerequisite: the Pi must be registered as a self-hosted runner with the label
+# `larshansen-pi`, and own the /var/www/* webroots. See infra/README.md.
+
+on:
+  push:
+    branches: [master] # TODO: switch to "main" once the default branch is renamed
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-pi
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, larshansen-pi]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build all apps
+        run: bun run build
+
+      - name: Publish to nginx webroots
+        run: |
+          set -euo pipefail
+          publish () { rsync -a --delete "apps/$1/dist/" "$2/"; }
+          publish landing   /var/www/larshansen.dev
+          publish portfolio /var/www/cv.larshansen.dev
+          publish iron-maze /var/www/maze.larshansen.dev

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,90 @@
+# Hosting — Raspberry Pi + Cloudflare Tunnel
+
+The apps are static builds served from nginx on the Pi, exposed publicly through a
+Cloudflare Tunnel. No port-forwarding, so it works behind the home double-NAT and
+survives a dynamic home IP.
+
+```
+push to master ─▶ self-hosted GitHub runner ON the Pi  (outbound only)
+                  bun install && bun run build
+                          │ rsync dist/ ─▶ /var/www/<host>
+                          ▼
+   nginx 127.0.0.1:8080 ── larshansen.dev · cv.* · maze.*
+                          ▲
+   cloudflared tunnel ────┘  (outbound to Cloudflare)
+                          ▲
+   Cloudflare edge (TLS) ─┘  (larshansen.dev zone moved here)
+```
+
+| Host | App |
+|------|-----|
+| `larshansen.dev` | `apps/landing` (the platform game) |
+| `cv.larshansen.dev` | `apps/portfolio` |
+| `maze.larshansen.dev` | `apps/iron-maze` |
+
+## One-time setup
+
+### 1. Move the domain to Cloudflare
+`larshansen.dev` currently uses Namecheap DNS (`registrar-servers.com`) and its A
+record points at the home IP.
+
+1. Cloudflare dashboard → **Add a site** → `larshansen.dev` (Free plan). Cloudflare
+   imports existing records — you can delete the old A record; the tunnel adds its own.
+2. Copy the two Cloudflare nameservers it shows.
+3. Namecheap → Domain → **Nameservers → Custom DNS** → paste the two CF nameservers.
+   Propagation is usually minutes to a couple of hours.
+
+### 2. Pi: nginx + webroots
+```bash
+sudo apt update && sudo apt install -y nginx rsync
+# webroots, owned by the runner user (no sudo needed at deploy time)
+sudo mkdir -p /var/www/{larshansen.dev,cv.larshansen.dev,maze.larshansen.dev}
+sudo chown -R "$USER":"$USER" /var/www/larshansen.dev /var/www/cv.larshansen.dev /var/www/maze.larshansen.dev
+# nginx site (file is in this repo)
+sudo cp infra/nginx/larshansen.conf /etc/nginx/sites-available/larshansen.conf
+sudo ln -sf /etc/nginx/sites-available/larshansen.conf /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### 3. Pi: Cloudflare Tunnel
+```bash
+# install cloudflared (arm64)
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64 \
+  -o /usr/local/bin/cloudflared && sudo chmod +x /usr/local/bin/cloudflared
+
+cloudflared tunnel login                 # opens a browser; pick the larshansen.dev zone
+cloudflared tunnel create larshansen     # note the TUNNEL_ID it prints
+
+# config: copy the example and fill in TUNNEL_ID
+sudo mkdir -p /etc/cloudflared
+sudo cp infra/cloudflared/config.example.yml /etc/cloudflared/config.yml
+sudo sed -i "s/TUNNEL_ID/<the-id>/g" /etc/cloudflared/config.yml
+
+# DNS routes (creates the CNAMEs to the tunnel)
+cloudflared tunnel route dns larshansen larshansen.dev
+cloudflared tunnel route dns larshansen cv.larshansen.dev
+cloudflared tunnel route dns larshansen maze.larshansen.dev
+
+# run as a service
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+```
+
+### 4. Pi: GitHub Actions self-hosted runner
+GitHub → repo **Settings → Actions → Runners → New self-hosted runner** (Linux/ARM64).
+Follow the shown commands, then when configuring add the label so the workflow targets it:
+```bash
+./config.sh --url https://github.com/larsekhansen/larshansen --token <token> --labels larshansen-pi
+sudo ./svc.sh install && sudo ./svc.sh start
+```
+Make sure the runner user owns the `/var/www/*` dirs from step 2.
+
+### 5. Deploy
+Push to `master` (or run the **Deploy to Raspberry Pi** workflow manually). The runner
+builds the monorepo and publishes each app to its webroot.
+
+## Notes
+- `.github/workflows/deploy.yml` triggers on `master` — update to `main` when the
+  default branch is renamed.
+- TLS is handled by Cloudflare; nginx stays plain HTTP on localhost.
+- Old `HOSTINGER_FTP_*` repo secrets are leftovers from 2021 and can be deleted.

--- a/infra/cloudflared/config.example.yml
+++ b/infra/cloudflared/config.example.yml
@@ -1,0 +1,16 @@
+# cloudflared tunnel config for the Pi.
+# Copy to /etc/cloudflared/config.yml (or ~/.cloudflared/config.yml) and replace
+# TUNNEL_ID with the id printed by `cloudflared tunnel create larshansen`.
+
+tunnel: TUNNEL_ID
+credentials-file: /home/lars/.cloudflared/TUNNEL_ID.json
+
+ingress:
+  - hostname: larshansen.dev
+    service: http://localhost:8080
+  - hostname: cv.larshansen.dev
+    service: http://localhost:8080
+  - hostname: maze.larshansen.dev
+    service: http://localhost:8080
+  # everything else gets a 404
+  - service: http_status:404

--- a/infra/nginx/larshansen.conf
+++ b/infra/nginx/larshansen.conf
@@ -1,0 +1,38 @@
+# Static hosting for the larshansen monorepo apps.
+#
+# Cloudflare Tunnel (cloudflared) forwards each hostname to http://localhost:8080,
+# so TLS is terminated at the Cloudflare edge and nginx only speaks plain HTTP here.
+# Each app is a client-side SPA, so unknown paths fall back to index.html.
+#
+# Install: copy to /etc/nginx/sites-available/larshansen.conf, symlink into
+# sites-enabled, then `sudo nginx -t && sudo systemctl reload nginx`.
+
+server {
+    listen 127.0.0.1:8080;
+    server_name larshansen.dev;
+    root /var/www/larshansen.dev;
+    index index.html;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+    listen 127.0.0.1:8080;
+    server_name cv.larshansen.dev;
+    root /var/www/cv.larshansen.dev;
+    index index.html;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+    listen 127.0.0.1:8080;
+    server_name maze.larshansen.dev;
+    root /var/www/maze.larshansen.dev;
+    index index.html;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Setter opp hosting av appene fra Raspberry Pi-en, eksponert via Cloudflare Tunnel (ingen portåpning, takler dobbel-NAT og dynamisk hjemme-IP).

**Arkitektur**
- Self-hosted GitHub-runner på Pi-en bygger monorepoet (`bun install && bun run build`) og rsync-er `dist/` til nginx sine webroots.
- nginx serverer statisk på `localhost:8080`; cloudflared sender hver subdomene dit. TLS termineres i Cloudflare-kanten.
- `larshansen.dev` → landing, `cv.larshansen.dev` → portfolio, `maze.larshansen.dev` → iron-maze.

**Filer**
- `.github/workflows/deploy.yml` – bygg + publiser (trigger: push til master)
- `infra/nginx/larshansen.conf` – tre server-blokker med SPA-fallback
- `infra/cloudflared/config.example.yml` – tunnel-ingress
- `infra/README.md` – kjøreplan for engangsoppsettet (domene til Cloudflare, nginx, tunnel, runner)

Engangsstegene som trenger kontoene dine (Cloudflare-sone + Namecheap NS-bytte, cloudflared og runner på Pi-en) er beskrevet i `infra/README.md`. Workflowen kjører ikke før en runner med label `larshansen-pi` er registrert, så det er trygt å merge før resten er på plass.
