### PR TITLE
infra: docs match the live setup (8090, remotely-managed tunnel)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,19 +1,19 @@
 # Hosting — Raspberry Pi + Cloudflare Tunnel
 
-The apps are static builds served from nginx on the Pi, exposed publicly through a
-Cloudflare Tunnel. No port-forwarding, so it works behind the home double-NAT and
-survives a dynamic home IP.
+**Live.** The apps are static builds served by nginx on the Pi, exposed through a
+Cloudflare Tunnel — no port-forwarding, so it works behind the home double-NAT and a
+dynamic home IP.
 
 ```
 push to master ─▶ self-hosted GitHub runner ON the Pi  (outbound only)
                   bun install && bun run build
                           │ rsync dist/ ─▶ /var/www/<host>
                           ▼
-   nginx 127.0.0.1:8080 ── larshansen.dev · cv.* · maze.*
+   nginx 127.0.0.1:8090 ── larshansen.dev · cv.* · maze.*   (8090: 8080 is Pi-hole)
                           ▲
-   cloudflared tunnel ────┘  (outbound to Cloudflare)
+   cloudflared tunnel ────┘  (remotely-managed; outbound to Cloudflare)
                           ▲
-   Cloudflare edge (TLS) ─┘  (larshansen.dev zone moved here)
+   Cloudflare edge (TLS) ─┘  (larshansen.dev zone on Cloudflare)
 ```
 
 | Host | App |
@@ -22,69 +22,30 @@ push to master ─▶ self-hosted GitHub runner ON the Pi  (outbound only)
 | `cv.larshansen.dev` | `apps/portfolio` |
 | `maze.larshansen.dev` | `apps/iron-maze` |
 
-## One-time setup
+## Deploying
+Just `git push` to `master`. The runner (`larshansen-pi`) builds the monorepo and
+rsyncs each app to its webroot. Manual run: GitHub → Actions → **Deploy to Raspberry Pi**
+→ Run workflow, or on the Pi: `cd ~/larshansen && git pull && PATH=~/.bun/bin:$PATH bun run build && rsync -a --delete apps/<app>/dist/ /var/www/<host>/`.
 
-### 1. Move the domain to Cloudflare
-`larshansen.dev` currently uses Namecheap DNS (`registrar-servers.com`) and its A
-record points at the home IP.
+## How it's wired (on the Pi)
+- **cloudflared** — systemd service, *remotely-managed* tunnel `larshansen` (connector
+  token, no local `config.yml`). Ingress + DNS live in Cloudflare, not on the Pi.
+- **nginx** — `/etc/nginx/sites-enabled/larshansen.conf`, three server blocks on
+  `127.0.0.1:8090`, SPA fallback to `index.html`.
+- **webroots** — `/var/www/{larshansen.dev,cv.larshansen.dev,maze.larshansen.dev}`,
+  owned by `lars` so the runner rsyncs without sudo.
+- **runner** — `~/actions-runner`, systemd service, label `larshansen-pi`.
 
-1. Cloudflare dashboard → **Add a site** → `larshansen.dev` (Free plan). Cloudflare
-   imports existing records — you can delete the old A record; the tunnel adds its own.
-2. Copy the two Cloudflare nameservers it shows.
-3. Namecheap → Domain → **Nameservers → Custom DNS** → paste the two CF nameservers.
-   Propagation is usually minutes to a couple of hours.
-
-### 2. Pi: nginx + webroots
-```bash
-sudo apt update && sudo apt install -y nginx rsync
-# webroots, owned by the runner user (no sudo needed at deploy time)
-sudo mkdir -p /var/www/{larshansen.dev,cv.larshansen.dev,maze.larshansen.dev}
-sudo chown -R "$USER":"$USER" /var/www/larshansen.dev /var/www/cv.larshansen.dev /var/www/maze.larshansen.dev
-# nginx site (file is in this repo)
-sudo cp infra/nginx/larshansen.conf /etc/nginx/sites-available/larshansen.conf
-sudo ln -sf /etc/nginx/sites-available/larshansen.conf /etc/nginx/sites-enabled/
-sudo nginx -t && sudo systemctl reload nginx
-```
-
-### 3. Pi: Cloudflare Tunnel
-```bash
-# install cloudflared (arm64)
-curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64 \
-  -o /usr/local/bin/cloudflared && sudo chmod +x /usr/local/bin/cloudflared
-
-cloudflared tunnel login                 # opens a browser; pick the larshansen.dev zone
-cloudflared tunnel create larshansen     # note the TUNNEL_ID it prints
-
-# config: copy the example and fill in TUNNEL_ID
-sudo mkdir -p /etc/cloudflared
-sudo cp infra/cloudflared/config.example.yml /etc/cloudflared/config.yml
-sudo sed -i "s/TUNNEL_ID/<the-id>/g" /etc/cloudflared/config.yml
-
-# DNS routes (creates the CNAMEs to the tunnel)
-cloudflared tunnel route dns larshansen larshansen.dev
-cloudflared tunnel route dns larshansen cv.larshansen.dev
-cloudflared tunnel route dns larshansen maze.larshansen.dev
-
-# run as a service
-sudo cloudflared service install
-sudo systemctl enable --now cloudflared
-```
-
-### 4. Pi: GitHub Actions self-hosted runner
-GitHub → repo **Settings → Actions → Runners → New self-hosted runner** (Linux/ARM64).
-Follow the shown commands, then when configuring add the label so the workflow targets it:
-```bash
-./config.sh --url https://github.com/larsekhansen/larshansen --token <token> --labels larshansen-pi
-sudo ./svc.sh install && sudo ./svc.sh start
-```
-Make sure the runner user owns the `/var/www/*` dirs from step 2.
-
-### 5. Deploy
-Push to `master` (or run the **Deploy to Raspberry Pi** workflow manually). The runner
-builds the monorepo and publishes each app to its webroot.
+## Managed in Cloudflare (not the Pi)
+- **Tunnel ingress** — Zero Trust → Networks → Tunnels → `larshansen` → Public hostnames
+  (each hostname → `http://localhost:8090`).
+- **DNS** — three proxied `CNAME`s (`@`, `cv`, `maze`) → `<tunnel-id>.cfargotunnel.com`.
+  The `MX`/`TXT` records are Namecheap email forwarding — leave them.
 
 ## Notes
-- `.github/workflows/deploy.yml` triggers on `master` — update to `main` when the
-  default branch is renamed.
-- TLS is handled by Cloudflare; nginx stays plain HTTP on localhost.
-- Old `HOSTINGER_FTP_*` repo secrets are leftovers from 2021 and can be deleted.
+- `.github/workflows/deploy.yml` triggers on `master` — switch to `main` if the default
+  branch is renamed.
+- TLS is terminated at Cloudflare; nginx stays plain HTTP on localhost.
+- Old `HOSTINGER_FTP_*` repo secrets (2021) are dead — safe to delete.
+- `infra/cloudflared/config.example.yml` is the *alternative* locally-managed setup
+  (not what's running) — kept only for reference.

--- a/infra/cloudflared/config.example.yml
+++ b/infra/cloudflared/config.example.yml
@@ -1,16 +1,18 @@
-# cloudflared tunnel config for the Pi.
-# Copy to /etc/cloudflared/config.yml (or ~/.cloudflared/config.yml) and replace
-# TUNNEL_ID with the id printed by `cloudflared tunnel create larshansen`.
+# ALTERNATIVE / reference only — NOT what's running.
+# The live tunnel is *remotely-managed* (connector token + ingress in the Cloudflare
+# dashboard); there is no config.yml on the Pi. Use this only if you switch to a
+# locally-managed tunnel: copy to /etc/cloudflared/config.yml and replace TUNNEL_ID
+# with the id from `cloudflared tunnel create larshansen`.
 
 tunnel: TUNNEL_ID
 credentials-file: /home/lars/.cloudflared/TUNNEL_ID.json
 
 ingress:
   - hostname: larshansen.dev
-    service: http://localhost:8080
+    service: http://localhost:8090
   - hostname: cv.larshansen.dev
-    service: http://localhost:8080
+    service: http://localhost:8090
   - hostname: maze.larshansen.dev
-    service: http://localhost:8080
+    service: http://localhost:8090
   # everything else gets a 404
   - service: http_status:404

--- a/infra/nginx/larshansen.conf
+++ b/infra/nginx/larshansen.conf
@@ -1,14 +1,15 @@
 # Static hosting for the larshansen monorepo apps.
 #
-# Cloudflare Tunnel (cloudflared) forwards each hostname to http://localhost:8080,
+# Cloudflare Tunnel (cloudflared) forwards each hostname to http://localhost:8090,
 # so TLS is terminated at the Cloudflare edge and nginx only speaks plain HTTP here.
+# Port 8090 (not 80/8080) because Pi-hole already maps host port 8080.
 # Each app is a client-side SPA, so unknown paths fall back to index.html.
 #
 # Install: copy to /etc/nginx/sites-available/larshansen.conf, symlink into
 # sites-enabled, then `sudo nginx -t && sudo systemctl reload nginx`.
 
 server {
-    listen 127.0.0.1:8080;
+    listen 127.0.0.1:8090;
     server_name larshansen.dev;
     root /var/www/larshansen.dev;
     index index.html;
@@ -18,7 +19,7 @@ server {
 }
 
 server {
-    listen 127.0.0.1:8080;
+    listen 127.0.0.1:8090;
     server_name cv.larshansen.dev;
     root /var/www/cv.larshansen.dev;
     index index.html;
@@ -28,7 +29,7 @@ server {
 }
 
 server {
-    listen 127.0.0.1:8080;
+    listen 127.0.0.1:8090;
     server_name maze.larshansen.dev;
     root /var/www/maze.larshansen.dev;
     index index.html;


### PR DESCRIPTION
Brings the committed infra docs in line with what's actually deployed:
- nginx + tunnel use port **8090** (host 8080 is Pi-hole)
- tunnel is **remotely-managed** (connector token + ingress in Cloudflare) — no `config.yml` on the Pi; `config.example.yml` kept as reference only
- `infra/README.md` rewritten to describe the running setup + how to deploy