### PR TITLE
Fix: landing game renders in production (was blank)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ name: Deploy to Raspberry Pi
 
 on:
   push:
-    branches: [master] # TODO: switch to "main" once the default branch is renamed
+    branches: [master, main] # works on the current default and survives a master→main rename
   workflow_dispatch:
 
 concurrency:

--- a/apps/landing/src/game/VikingGame.tsx
+++ b/apps/landing/src/game/VikingGame.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { EventController } from "./eventController";
 import initGame from "./game";
 
 if (import.meta.hot) {
@@ -8,19 +7,17 @@ if (import.meta.hot) {
 
 const VikingGame = () => {
   const gameRef = useRef<HTMLDivElement>(null);
-  const isMounted = useRef(false);
+  const startedRef = useRef(false);
 
   useEffect(() => {
-    if (!isMounted.current) {
-      return (isMounted.current = true) && undefined;
-    }
+    // React StrictMode invokes effects twice in dev; guard so the game inits
+    // exactly once. (The previous guard skipped the *first* run, so in a
+    // production build — where the effect fires only once — it never ran and
+    // the page rendered blank.)
+    if (startedRef.current) return;
+    startedRef.current = true;
 
     initGame(gameRef);
-
-    return () => {
-      const { cleanupEventListeners } = new EventController();
-      cleanupEventListeners();
-    };
   }, []);
 
   return <div id="game" ref={gameRef} />;


### PR DESCRIPTION
`larshansen.dev` currently renders nothing — `VikingGame`'s StrictMode guard was inverted, so `initGame` only ran on the *second* effect invocation. StrictMode double-invokes effects in dev (worked locally) but not in production builds, so the game never initialised and the page was blank.

- Guard now inits the game exactly once in both dev and prod (verified against a production `vite preview` build — canvas renders).
- `deploy.yml` now triggers on `master` **and** `main`, so it keeps working through a future rename.

Merging this auto-deploys to the Pi and makes the game appear.